### PR TITLE
fixed an issue where temp lines get flipped when both temps are negative and an optional null value

### DIFF
--- a/src/apis/bom/models.rs
+++ b/src/apis/bom/models.rs
@@ -180,7 +180,7 @@ pub struct HourlyForecast {
     // pub dew_point: i16,
     pub wind: Wind,
     pub relative_humidity: RelativeHumidity,
-    pub uv: HourlyUV,
+    pub uv: Option<HourlyUV>,
     // pub icon_descriptor: String,
     // pub next_three_hourly_forecast_period: DateTime<Utc>,
     pub time: DateTime<Utc>,

--- a/src/dashboard/chart.rs
+++ b/src/dashboard/chart.rs
@@ -562,9 +562,9 @@ impl HourlyForecastGraph {
                 CurveType::ActualTemp(_) | CurveType::TempFeelLike(_) => {
                     if self.max_y >= 0.0 && self.min_y < 0.0 {
                         self.height / (self.max_y + self.min_y.abs())
-                    } else if self.min_y < 0.0 {
-                        // it's possible for both to be negative
-                        self.height / (self.max_y.abs() - self.min_y.abs())
+                    } else if self.min_y < 0.0 && self.max_y < 0.0 {
+                        // both are negative - use the absolute difference
+                        self.height / (self.min_y.abs() - self.max_y.abs())
                     } else {
                         // when both are positive
                         self.height / (self.max_y - self.min_y)

--- a/src/domain/models.rs
+++ b/src/domain/models.rs
@@ -200,7 +200,7 @@ impl From<crate::apis::bom::models::HourlyForecast> for HourlyForecast {
                 bom.rain.amount.min,
                 bom.rain.amount.max,
             ),
-            uv_index: bom.uv.0,
+            uv_index: bom.uv.unwrap_or_default().0,
             relative_humidity: bom.relative_humidity.0,
             is_night: bom.is_night,
         }

--- a/tests/bom_provider_test.rs
+++ b/tests/bom_provider_test.rs
@@ -94,7 +94,10 @@ fn test_bom_hourly_fields() {
         if let Some(chance) = forecast.rain.chance {
             assert!(chance <= 100, "Rain chance should be <= 100%");
         }
-        assert!(forecast.uv.0 < 20, "UV index should be < 20");
+        assert!(
+            forecast.uv.unwrap_or_default().0 < 20,
+            "UV index should be < 20"
+        );
     }
 }
 


### PR DESCRIPTION
- fixed an issue where temp lines get flipped when both temps are negative
- fixed an issue with bom where uv returned null instead of valid value