### PR TITLE
Add debug info overlay (version, provider, location, timezone)

### DIFF
--- a/dashboard-template-min.svg
+++ b/dashboard-template-min.svg
@@ -58,6 +58,19 @@
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="{debug_info_visibility}">
+        <text x="90" y="0" font-size="9" fill="{text_colour}">
+            {debug_version}
+        </text>
+        <text x="90" y="10" font-size="8" fill="{text_colour}">
+            {debug_provider}
+        </text>
+        <text x="90" y="18" font-size="7" fill="{text_colour}">
+            {debug_location} {debug_timezone}
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="{sunrise_icon}" />

--- a/src/dashboard/context.rs
+++ b/src/dashboard/context.rs
@@ -97,6 +97,12 @@ pub struct Context {
     pub diagnostic_visibility: String,
     // cascading diagnostic icons (SVG fragments for multiple stacked icons)
     pub diagnostic_icons_svg: String,
+    // Debug information (displayed when debugging enabled)
+    pub debug_info_visibility: String,
+    pub debug_version: String,
+    pub debug_provider: String,
+    pub debug_location: String,
+    pub debug_timezone: String,
 }
 
 impl Default for Context {
@@ -181,6 +187,11 @@ impl Default for Context {
             diagnostic_message: na,
             diagnostic_visibility: ElementVisibility::Hidden.to_string(),
             diagnostic_icons_svg: String::new(),
+            debug_version: String::new(),
+            debug_info_visibility: ElementVisibility::Hidden.to_string(),
+            debug_provider: String::new(),
+            debug_location: String::new(),
+            debug_timezone: String::new(),
         }
     }
 }
@@ -198,8 +209,26 @@ impl Default for ContextBuilder {
 
 impl ContextBuilder {
     pub fn new() -> Self {
+        let mut context = Context::default();
+
+        if CONFIG.debugging.enable_debug_logs {
+            context.debug_info_visibility = ElementVisibility::Visible.to_string();
+            context.debug_version = format!("v{}", env!("CARGO_PKG_VERSION"));
+
+            context.debug_provider = CONFIG.api.provider.to_string();
+
+            // Location with reduced precision for privacy (1 decimal place ≈ 11km accuracy)
+            let lat = CONFIG.api.latitude.into_inner();
+            let lon = CONFIG.api.longitude.into_inner();
+            context.debug_location = format!("{:.1}, {:.1}", lat, lon);
+
+            // Timezone offset (e.g., "+11:00" or "-05:00")
+            let now = chrono::Local::now();
+            context.debug_timezone = now.format("%z").to_string();
+        }
+
         Self {
-            context: Context::default(),
+            context,
             diagnostics: Vec::new(),
         }
     }

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_dashboard.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_dashboard.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/snapshot_provider_test.rs
-assertion_line: 367
 expression: svg_content
 ---
 <svg width="800" height="480" font-family="Roboto, sans-serif" xmlns="http://www.w3.org/2000/svg">
@@ -60,6 +59,19 @@ expression: svg_content
         <!-- Message for highest priority error only -->
         <text x="100" y="60" width="200" font-size="12">
             NA
+        </text>
+    </svg>
+
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            Bom
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
         </text>
     </svg>
 

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_early_morning.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_early_morning.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/snapshot_provider_test.rs
-assertion_line: 508
 expression: svg_content
 ---
 <svg width="800" height="480" font-family="Roboto, sans-serif" xmlns="http://www.w3.org/2000/svg">
@@ -60,6 +59,19 @@ expression: svg_content
         <!-- Message for highest priority error only -->
         <text x="100" y="60" width="200" font-size="12">
             NA
+        </text>
+    </svg>
+
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            Bom
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
         </text>
     </svg>
 

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_local_midnight.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_local_midnight.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/snapshot_provider_test.rs
-assertion_line: 459
 expression: svg_content
 ---
 <svg width="800" height="480" font-family="Roboto, sans-serif" xmlns="http://www.w3.org/2000/svg">
@@ -60,6 +59,19 @@ expression: svg_content
         <!-- Message for highest priority error only -->
         <text x="100" y="60" width="200" font-size="12">
             NA
+        </text>
+    </svg>
+
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            Bom
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
         </text>
     </svg>
 

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_midnight_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_midnight_boundary.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/snapshot_provider_test.rs
-assertion_line: 413
 expression: svg_content
 ---
 <svg width="800" height="480" font-family="Roboto, sans-serif" xmlns="http://www.w3.org/2000/svg">
@@ -60,6 +59,19 @@ expression: svg_content
         <!-- Message for highest priority error only -->
         <text x="100" y="60" width="200" font-size="12">
             NA
+        </text>
+    </svg>
+
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            Bom
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
         </text>
     </svg>
 

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_dashboard.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_dashboard.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_early_morning.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_early_morning.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_end_of_day.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_end_of_day.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_midnight_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_midnight_boundary.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 +1100
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_6pm_before_gmt_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_6pm_before_gmt_boundary.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 -0500
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_7pm_after_gmt_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_7pm_after_gmt_boundary.snap
@@ -62,6 +62,19 @@ expression: svg_content
         </text>
     </svg>
 
+    <!-- Version Information (displayed when debugging enabled) -->
+    <svg x="690" y="15" width="100" height="20" text-anchor="end" visibility="visible">
+        <text x="90" y="0" font-size="9" fill="black">
+            v0.8.2-beta.1
+        </text>
+        <text x="90" y="10" font-size="8" fill="black">
+            OpenMeteo
+        </text>
+        <text x="90" y="18" font-size="7" fill="black">
+            -37.8, 145.0 -0500
+        </text>
+    </svg>
+
     <!-- Sunset/Sunrise Information -->
     <svg x="30" y="150">
         <image x="0" y="0" width="75" height="75" href="static/fill-svg-static/sunrise.svg" />


### PR DESCRIPTION
Displays when enable_debug_logs is enabled. Location coordinates are privacy-preserving with 1 decimal place precision.