### PR TITLE
UV gradient bar uses page background colour for zero-UV, not hardcoded white

### DIFF
--- a/src/dashboard/chart.rs
+++ b/src/dashboard/chart.rs
@@ -114,6 +114,10 @@ pub struct HourlyForecastGraph {
     pub y_right_ticks: u16,
     pub x_axis_always_at_min: bool,
     pub text_colour: String,
+    /// Used as the UV gradient bar's colour for zero-UV hours, so it blends
+    /// into the page in any theme instead of a hardcoded white standing out
+    /// against a dark background.
+    pub background_colour: String,
     /// Display timezone for time-dependent labels (e.g. the "tomorrow" day name).
     pub tz: chrono_tz::Tz,
 }
@@ -146,6 +150,7 @@ impl Default for HourlyForecastGraph {
             y_right_ticks: 5,
             x_axis_always_at_min: false,
             text_colour: "black".to_string(),
+            background_colour: "white".to_string(),
             tz: chrono_tz::UTC,
         }
     }
@@ -706,7 +711,7 @@ impl HourlyForecastGraph {
 
         for (i, &uv) in self.uv_data.iter().enumerate() {
             let offset = (i as f32 / 23.0) * 100.0;
-            let colour = UVIndexIcon::from(uv).to_colour();
+            let colour = UVIndexIcon::from(uv).to_colour(&self.background_colour);
             gradient.push_str(&format!(
                 r#"<stop offset="{offset:.2}%" stop-color="{colour}"/>"#
             ));

--- a/src/dashboard/context.rs
+++ b/src/dashboard/context.rs
@@ -522,6 +522,7 @@ impl<'a> ContextBuilder<'a> {
         let mut graph = HourlyForecastGraph {
             x_axis_always_at_min: self.settings.render_options.x_axis_always_at_min,
             text_colour: self.settings.colours.text_colour.to_string(),
+            background_colour: self.settings.colours.background_colour.to_string(),
             tz: self.settings.misc.timezone,
             ..Default::default()
         };

--- a/src/weather/icons.rs
+++ b/src/weather/icons.rs
@@ -131,14 +131,18 @@ impl From<u16> for UVIndexIcon {
 }
 
 impl UVIndexIcon {
-    pub fn to_colour(self) -> &'static str {
+    /// Colour for the UV gradient bar. `None` (zero UV, i.e. nighttime) uses
+    /// the dashboard's own background colour so it blends into the page in
+    /// any theme, rather than a fixed colour that would stand out against a
+    /// dark background.
+    pub fn to_colour(self, background_colour: &str) -> String {
         match self {
-            Self::None => "white",
-            Self::Low => "green",
-            Self::Moderate => "yellow",
-            Self::High => "orange",
-            Self::VeryHigh => "red",
-            Self::Extreme => "purple",
+            Self::None => background_colour.to_string(),
+            Self::Low => "green".to_string(),
+            Self::Moderate => "yellow".to_string(),
+            Self::High => "orange".to_string(),
+            Self::VeryHigh => "red".to_string(),
+            Self::Extreme => "purple".to_string(),
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

The UV gradient bar's zero-UV ("no UV", i.e. nighttime) segment was hardcoded to white. That's invisible on the light theme (white blends into a white page) but renders as a stark white bar cutting across a dark theme's black background.

Threads `colours.background_colour` through to `UVIndexIcon::to_colour` so the zero-UV segment blends into the page in any theme, instead of a fixed colour that only happens to work for one of them.

**Changes:**
- `UVIndexIcon::to_colour` takes `&str` (the background colour) instead of returning a hardcoded `&'static str` for the zero case
- `HourlyForecastGraph` gains a `background_colour` field, populated from `settings.colours.background_colour`

**Test status:** full suite green, no snapshot changes (nothing currently asserts on the UV gradient's rendered colour).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config

## Breaking changes?

<!-- Does this rename/remove config keys, change defaults, or alter behaviour that affects existing user setups? If so, describe what users need to update -->

## Tested on device?

<!-- For display or rendering changes: tested on real Raspberry Pi + Inky Impression hardware? (CI can't catch e-ink color/font/layout issues) -->

## Notes

<!-- If dashboard rendering changed, run `cargo insta review` and commit updated snapshots before CI will pass -->
