### PR TITLE
Nudge current-hour weather icon up by 5px

### DIFF
--- a/dashboard-template-min.svg
+++ b/dashboard-template-min.svg
@@ -54,7 +54,7 @@
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="{text_colour}" text-anchor="middle">{current_day_date}</text>
-    <image x="0" y="0" width="200" height="180" href="{current_hour_weather_icon}" />
+    <image x="0" y="-5" width="200" height="180" href="{current_hour_weather_icon}" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_dashboard_prefer_codes.snap
+++ b/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_dashboard_prefer_codes.snap
@@ -58,7 +58,7 @@ expression: svg
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Saturday, 25 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_early_morning_prefer_codes.snap
+++ b/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_early_morning_prefer_codes.snap
@@ -58,7 +58,7 @@ expression: svg
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-rain.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-rain.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_end_of_day_prefer_codes.snap
+++ b/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_end_of_day_prefer_codes.snap
@@ -58,7 +58,7 @@ expression: svg
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_midnight_boundary_prefer_codes.snap
+++ b/tests/snapshots/snapshot_open_meteo_prefer_codes_test__snapshot_open_meteo_midnight_boundary_prefer_codes.snap
@@ -58,7 +58,7 @@ expression: svg
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day-drizzle.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_precipitation_test__snapshot_open_meteo_alaska_snow.snap
+++ b/tests/snapshots/snapshot_precipitation_test__snapshot_open_meteo_alaska_snow.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Thursday, 15 January</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/extreme-night-snow.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/extreme-night-snow.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_precipitation_test__snapshot_open_meteo_mixed_precip.snap
+++ b/tests/snapshots/snapshot_precipitation_test__snapshot_open_meteo_mixed_precip.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 01 February</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-day.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-day.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_dashboard.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_dashboard.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Saturday, 25 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-night-drizzle.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-night-drizzle.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_early_morning.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_early_morning.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-night-rain.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-night-rain.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_local_midnight.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_local_midnight.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-night-drizzle.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-night-drizzle.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_bom_midnight_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_bom_midnight_boundary.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-day-rain.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-day-rain.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_dashboard.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_dashboard.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Saturday, 25 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/partly-cloudy-day.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_early_morning.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_early_morning.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/extreme-day-rain.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/extreme-day-rain.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_end_of_day.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_end_of_day.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-day.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-day.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_midnight_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_midnight_boundary.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 26 October</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-day-rain.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-day-rain.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_6pm_before_gmt_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_6pm_before_gmt_boundary.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 28 December</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/overcast-night.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/overcast-night.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->

--- a/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_7pm_after_gmt_boundary.snap
+++ b/tests/snapshots/snapshot_provider_test__snapshot_open_meteo_ny_7pm_after_gmt_boundary.snap
@@ -58,7 +58,7 @@ expression: svg_content
     <!-- Due to resvg bug, the position is intentionally off to compensate for the bug -->
     <!-- Do not modify the x position of current_hour_temp and current_hour_feels_like, see above issue at the start of the file -->
     <text x="400" y="50" font-size="35" fill="black" text-anchor="middle">Sunday, 28 December</text>
-    <image x="0" y="0" width="200" height="180" href="static/fill-svg-static/clear-night.svg" />
+    <image x="0" y="-5" width="200" height="180" href="static/fill-svg-static/clear-night.svg" />
 
 
     <!-- Current temperature and Feels Like temperature -->


### PR DESCRIPTION
## What does this PR do?
Small vertical alignment adjustment to the main current-hour icon in the dashboard template (`y="0"` → `y="-5"`).

**Changes:**
- `dashboard-template-min.svg`: current-hour icon's `y` position
- All 16 snapshot tests updated to match — every snapshot's current-hour `<image>` tag shifts `y="0"` → `y="-5"`; icon *selection* itself is unaffected (verified each diff changes only the `y` attribute, not the icon filename)

**Test status:** full suite green, snapshots already accepted and committed on this branch.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs / config

## Breaking changes?

<!-- Does this rename/remove config keys, change defaults, or alter behaviour that affects existing user setups? If so, describe what users need to update -->

## Tested on device?

<!-- For display or rendering changes: tested on real Raspberry Pi + Inky Impression hardware? (CI can't catch e-ink color/font/layout issues) -->

## Notes

<!-- If dashboard rendering changed, run `cargo insta review` and commit updated snapshots before CI will pass -->
