### PR TITLE
Retry transient body-level API errors instead of failing after one attempt

### DIFF
--- a/src/providers/fetcher.rs
+++ b/src/providers/fetcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 use serde::Deserialize;
-use std::{fs, path::PathBuf, time::Duration};
+use std::{fmt, fs, path::PathBuf, time::Duration};
 use url::Url;
 
 use crate::configs::settings::DashboardSettings;
@@ -8,6 +8,28 @@ use crate::{errors::DashboardError, logger};
 
 /// Type alias for API-specific error checking function
 pub type ErrorChecker = fn(&str) -> Result<(), DashboardError>;
+
+/// Wraps a `DashboardError` produced by an `ErrorChecker` (a body-level API error, as
+/// opposed to a `reqwest::Error`) to signal to `try_fetch_with_retry` that this is a
+/// transient error worth retrying with backoff, rather than an immediate fallback.
+///
+/// Retryability is decided by HTTP status in `process_successful_response`: a 4xx status
+/// (e.g. Open-Meteo returning 400 for an invalid parameter) indicates a problem with the
+/// request itself that will fail identically on every retry, so those fall back to cached
+/// data immediately instead of being wrapped here. Anything else (5xx, or a 2xx response
+/// whose body still signals an error, e.g. Open-Meteo's "The service is overloaded") is
+/// assumed to be transient and gets wrapped so it flows through the same retry path as
+/// network errors.
+#[derive(Debug)]
+struct TransientApiError(DashboardError);
+
+impl fmt::Display for TransientApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for TransientApiError {}
 
 /// Configuration for retry behavior
 ///
@@ -179,18 +201,40 @@ impl Fetcher {
     /// Process a successful API response
     fn process_successful_response<T: for<'de> Deserialize<'de>>(
         &self,
+        status: reqwest::StatusCode,
         body: String,
         file_path: &PathBuf,
         error_checker: Option<ErrorChecker>,
     ) -> Result<FetchOutcome<T>, Error> {
         logger::debug(format!("Received API response: {} bytes", body.len()));
 
-        // Check for API-specific errors if checker provided
+        // Check for API-specific errors if checker provided.
         if let Some(checker) = error_checker {
             if let Err(dashboard_error) = checker(&body) {
                 use crate::errors::Description;
-                logger::warning(dashboard_error.long_description());
-                return self.fallback(file_path, dashboard_error);
+                logger::detail(format!(
+                    "Raw error details: {}",
+                    dashboard_error.long_description()
+                ));
+
+                // A 4xx status (other than 429, which is handled separately before this
+                // point) means the request itself is the problem - e.g. Open-Meteo
+                // rejecting an invalid parameter. That will fail identically on every
+                // retry, so log it and fall back to cached data immediately instead of
+                // wasting the retry budget.
+                if status.is_client_error() {
+                    logger::warning(format!(
+                        "API request failed: {}",
+                        dashboard_error.short_description()
+                    ));
+                    return self.fallback(file_path, dashboard_error);
+                }
+
+                // Otherwise (5xx, or a 2xx response whose body still signals an error,
+                // e.g. Open-Meteo's "The service is overloaded") treat it as transient
+                // and let `try_fetch_with_retry` retry it with backoff, the same way it
+                // retries network failures, instead of giving up after a single attempt.
+                return Err(TransientApiError(dashboard_error).into());
             }
         }
 
@@ -203,6 +247,14 @@ impl Fetcher {
     /// Handle fetch errors with logging (classify_error logs raw details internally)
     fn handle_fetch_error(&self, error: &reqwest::Error, attempt: usize, max_retries: usize) {
         let dashboard_error = Self::classify_error(error);
+        Self::log_attempt_warning(&dashboard_error, attempt, max_retries);
+    }
+
+    /// Log a short warning for a failed fetch attempt, framed as either the initial
+    /// attempt or a numbered retry. Shared by the network-error path
+    /// (`handle_fetch_error`) and the body-level transient API error path in
+    /// `try_fetch_with_retry`, so both log consistently.
+    fn log_attempt_warning(dashboard_error: &DashboardError, attempt: usize, max_retries: usize) {
         use crate::errors::Description;
 
         if attempt == 0 {
@@ -275,9 +327,10 @@ impl Fetcher {
         config: &RetryConfig,
     ) -> Result<FetchOutcome<T>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.client.get(endpoint.as_str()).send()?;
+        let status = response.status();
 
         // Check for 429 Too Many Requests with Retry-After header
-        if response.status().as_u16() == 429 {
+        if status.as_u16() == 429 {
             let retry_after = Self::handle_rate_limit_response(&response, attempt, config)?;
             std::thread::sleep(retry_after);
             // Return error to trigger retry
@@ -293,9 +346,12 @@ impl Fetcher {
         }
 
         let body = response.text()?;
-        match self.process_successful_response(body, file_path, error_checker) {
+        match self.process_successful_response(status, body, file_path, error_checker) {
             Ok(outcome) => Ok(outcome),
-            Err(e) => Err(Box::new(std::io::Error::other(e.to_string()))),
+            Err(e) => match e.downcast::<TransientApiError>() {
+                Ok(transient_error) => Err(Box::new(transient_error)),
+                Err(e) => Err(Box::new(std::io::Error::other(e.to_string()))),
+            },
         }
     }
 
@@ -352,6 +408,18 @@ impl Fetcher {
                             // No point of further retries, since the error is not retryable
                             break;
                         }
+                    } else if let Some(transient_error) = e.downcast_ref::<TransientApiError>() {
+                        // Transient application-level error from the response body (e.g.
+                        // Open-Meteo's "The service is overloaded"). Already classified as
+                        // retryable by `process_successful_response` based on HTTP status,
+                        // so just log and keep retrying with backoff, same as a network
+                        // failure.
+                        Self::log_attempt_warning(&transient_error.0, attempt, config.max_retries);
+
+                        if attempt == config.max_retries - 1 {
+                            last_error = Some(e);
+                            break;
+                        }
                     }
 
                     last_error = Some(e);
@@ -375,6 +443,8 @@ impl Fetcher {
             // Try to downcast to reqwest::Error for proper classification
             if let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() {
                 Ok(Self::classify_error(reqwest_err))
+            } else if let Some(transient_error) = e.downcast_ref::<TransientApiError>() {
+                Ok(transient_error.0.clone())
             } else {
                 Ok(DashboardError::NetworkError {
                     details: e.to_string(),
@@ -397,7 +467,12 @@ impl Fetcher {
     /// # Retry Strategy
     /// - Attempts up to 5 retries with exponential backoff (1s, 2s, 4s, 16s, 32s)
     /// - Respects HTTP 429 rate limit responses with Retry-After header
-    /// - Retries on: timeouts, connection failures, 5xx errors, 429 rate limits
+    /// - Retries on: timeouts, connection failures, 5xx errors, 429 rate limits, and
+    ///   transient body-level API errors (a 2xx/5xx response whose body still signals
+    ///   an error, e.g. Open-Meteo's "The service is overloaded")
+    /// - Does not retry a body-level API error accompanied by a 4xx status (other than
+    ///   429), since that indicates a problem with the request itself that would fail
+    ///   identically on every attempt
     /// - Falls back to cached data if all retries fail
     pub fn fetch_data<T>(
         &self,

--- a/tests/fetcher_test.rs
+++ b/tests/fetcher_test.rs
@@ -525,3 +525,199 @@ async fn test_retry_succeeds_on_third_attempt() {
         Err(e) => panic!("Expected success, got error: {}", e),
     }
 }
+
+/// Minimal stand-in for `check_open_meteo_error`/`check_bom_error`: treats any response
+/// body of the form `{"error": true, "reason": "..."}` as an API-level error. Used to
+/// exercise the generic retry behavior in `Fetcher` without depending on a specific
+/// provider's response schema.
+fn test_error_checker(body: &str) -> Result<(), DashboardError> {
+    #[derive(serde::Deserialize)]
+    struct TestApiError {
+        error: bool,
+        reason: String,
+    }
+
+    match serde_json::from_str::<TestApiError>(body) {
+        Ok(err) if err.error => Err(DashboardError::ApiError {
+            details: err.reason,
+        }),
+        _ => Ok(()),
+    }
+}
+
+#[tokio::test]
+async fn test_body_level_transient_error_is_retried_and_recovers() {
+    // A body-level error on a 2xx response (e.g. Open-Meteo's "The service is
+    // overloaded", which comes back without a 429/5xx status) should be retried with
+    // backoff just like a network failure, not treated as a final answer.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "error": true,
+            "reason": "The service is overloaded"
+        })))
+        .up_to_n_times(2)
+        .named("First two overloaded responses")
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/test"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"value": "success"})),
+        )
+        .named("Final success")
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/test", mock_server.uri());
+
+    let result = tokio::task::spawn_blocking(move || {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let cache_path = temp_dir.path().to_path_buf();
+        let fetcher = Fetcher::new(cache_path.clone());
+
+        let cache_file = cache_path.join("test_data.json");
+        std::fs::write(
+            &cache_file,
+            serde_json::to_string(&TestData {
+                value: "cached".to_string(),
+            })
+            .unwrap(),
+        )
+        .expect("Failed to write cache file");
+
+        const RETRY_DELAYS: &[Duration; 3] = &[
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        ];
+        let config = pi_inky_weather_epd::providers::fetcher::RetryConfig::new(
+            3,
+            RETRY_DELAYS,
+            Duration::from_secs(10),
+        );
+
+        let endpoint = url::Url::parse(&url).expect("Invalid URL");
+        fetcher.try_fetch_with_retry::<TestData>(
+            &endpoint,
+            &cache_file,
+            Some(test_error_checker),
+            &config,
+        )
+    })
+    .await
+    .expect("Task panicked");
+
+    match result {
+        Ok(pi_inky_weather_epd::providers::fetcher::FetchOutcome::Fresh(data)) => {
+            assert_eq!(data.value, "success");
+        }
+        Ok(pi_inky_weather_epd::providers::fetcher::FetchOutcome::Stale { data, error }) => {
+            panic!(
+                "Expected Fresh data after recovering from a transient body-level error, \
+                 got Stale: {:?}, error: {:?}",
+                data, error
+            );
+        }
+        Err(e) => panic!("Expected success, got error: {}", e),
+    }
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("request recording enabled");
+    assert_eq!(
+        requests.len(),
+        3,
+        "Expected exactly 3 requests (2 retried failures + 1 success)"
+    );
+}
+
+#[tokio::test]
+async fn test_body_level_client_error_is_not_retried() {
+    // A body-level error accompanied by a 4xx status (e.g. Open-Meteo rejecting an
+    // invalid parameter with HTTP 400) indicates a problem with the request itself.
+    // Retrying it will fail identically every time, so it should fall back to cached
+    // data after a single attempt instead of burning the retry budget.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/test"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "error": true,
+            "reason": "Invalid parameter: bad_variable"
+        })))
+        .named("Permanent client error")
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/test", mock_server.uri());
+
+    let result = tokio::task::spawn_blocking(move || {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let cache_path = temp_dir.path().to_path_buf();
+        let fetcher = Fetcher::new(cache_path.clone());
+
+        let cache_file = cache_path.join("test_data.json");
+        std::fs::write(
+            &cache_file,
+            serde_json::to_string(&TestData {
+                value: "cached".to_string(),
+            })
+            .unwrap(),
+        )
+        .expect("Failed to write cache file");
+
+        const RETRY_DELAYS: &[Duration; 5] = &[
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        ];
+        let config = pi_inky_weather_epd::providers::fetcher::RetryConfig::new(
+            5,
+            RETRY_DELAYS,
+            Duration::from_secs(10),
+        );
+
+        let endpoint = url::Url::parse(&url).expect("Invalid URL");
+        fetcher.try_fetch_with_retry::<TestData>(
+            &endpoint,
+            &cache_file,
+            Some(test_error_checker),
+            &config,
+        )
+    })
+    .await
+    .expect("Task panicked");
+
+    match result {
+        Ok(pi_inky_weather_epd::providers::fetcher::FetchOutcome::Stale { data, error }) => {
+            assert_eq!(data.value, "cached");
+            match error {
+                DashboardError::ApiError { details } => {
+                    assert!(details.contains("Invalid parameter"));
+                }
+                _ => panic!("Expected ApiError, got {:?}", error),
+            }
+        }
+        Ok(pi_inky_weather_epd::providers::fetcher::FetchOutcome::Fresh(_)) => {
+            panic!("Expected Stale fallback for a permanent client error");
+        }
+        Err(e) => panic!("Expected fallback to cache, got error: {}", e),
+    }
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("request recording enabled");
+    assert_eq!(
+        requests.len(),
+        1,
+        "Expected exactly 1 request - a 4xx body-level error must not be retried"
+    );
+}


### PR DESCRIPTION
## What does this PR do?


## Summary

- Open-Meteo (and BOM) sometimes return a body-level error — e.g.   `{"error":true,"reason":"The service is overloaded"}` — on an HTTP status   that isn't a network-layer failure. This bypassed the existing 5-attempt exponential-backoff retry logic entirely, falling back to cached data  after a single attempt even when the same request would very likely succeed seconds later 
- Retryability for these body-level errors is now decided by HTTP status, mirroring the existing convention for network-layer errors: a 4xx status   (e.g. Open-Meteo rejecting an invalid parameter with HTTP 400) indicates a   problem with the request itself that will fail identically on every retry, so it falls back to cache immediately. Anything else (5xx, or a   2xx response whose body still signals an error) is treated as transient and retried with the same backoff schedule (1s, 2s, 4s, 16s, 32s) already   used for network failures.
- This applies uniformly to both providers (Open-Meteo and BOM) with no provider-specific code changes, since both route through the same `Fetcher::fetch_data` / `try_fetch_with_retry` path.
- Also fixes a latent logging gap surfaced during review: the permanent (4xx) fallback path previously logged nothing before falling back (silent failure), and the new transient-error logging duplicated an existing helper instead of reusing it. Both cleaned up. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config

## Breaking changes?

None

## Tested on device?
pizero

## Notes

<!-- If dashboard rendering changed, run `cargo insta review` and commit updated snapshots before CI will pass -->
