### PR TITLE
Add proptest coverage for domain arithmetic and config validation; fix two panics it found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ cross = "0.2"                                                            # neede
 wiremock = "0.6.5"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
 chrono-tz = "0.10"
+proptest = "1"
 
 
 [profile.dev.package]

--- a/proptest-regressions/configs/validation.txt
+++ b/proptest-regressions/configs/validation.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 55a52eb0f8ff9810c0dc0174ecc156b8b2463c44a62c0df5c5a7e7a42f486c52 # shrinks to format = "%{"

--- a/proptest-regressions/domain/models.txt
+++ b/proptest-regressions/domain/models.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9e944a74861d8db0e7fcf874b7994606588c30acf51d64e4932ce31963f2f25f # shrinks to amount_min = 52403, amount_max = 13133
+cc f2f89b95de18e43164d472e98cb473710a3eff726278021a9226cbfc70158553 # shrinks to amount_min = 32768, amount_max = 32768

--- a/src/configs/validation.rs
+++ b/src/configs/validation.rs
@@ -370,8 +370,21 @@ pub fn is_valid_date_format(format: &str) -> Result<(), ValidationError> {
     // Test the format by formatting the longest possible date
     // Wednesday (9 chars) + September (9 chars) = longest day + month combination
     use chrono::{TimeZone, Utc};
+    use std::fmt::Write;
     let longest_date = Utc.with_ymd_and_hms(2025, 9, 17, 12, 0, 0).unwrap(); // Wednesday, 17 September 2025
-    let formatted = longest_date.format(trimmed).to_string();
+
+    // Write into a buffer instead of calling `.to_string()`: chrono's
+    // `DelayedFormat::fmt` can return `Err` for certain malformed specifiers
+    // (e.g. an unterminated "%{"), and `ToString::to_string()` assumes
+    // `Display::fmt` never fails — it panics instead of propagating the
+    // error, which would otherwise crash config loading instead of cleanly
+    // rejecting the format.
+    let mut formatted = String::new();
+    if write!(formatted, "{}", longest_date.format(trimmed)).is_err() {
+        return Err(ValidationError::new(
+            "Date format contains an invalid or unsupported specifier",
+        ));
+    }
 
     // Check output length
     if formatted.len() > MAX_DATE_FORMAT_OUTPUT_LENGTH {
@@ -572,6 +585,23 @@ mod tests {
             let format = "%A, %-d %B %Y";
             assert!(is_valid_date_format(format).is_ok());
             assert_eq!(format_longest_date(format), "Sunday, 28 September 2025");
+        }
+    }
+
+    mod fuzzing {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// `format` is user-controlled config, not API data, but it still
+            /// reaches chrono's `strftime`-style formatter with no prior
+            /// sanitization beyond the empty/whitespace check — arbitrary
+            /// strings (unicode, unmatched `%` sequences, huge inputs) should
+            /// never panic, only return `Ok`/`Err`.
+            #[test]
+            fn never_panics_on_arbitrary_input(format in ".*") {
+                let _ = is_valid_date_format(&format);
+            }
         }
     }
 }

--- a/src/domain/models.rs
+++ b/src/domain/models.rs
@@ -178,7 +178,10 @@ impl Precipitation {
     pub fn median(&self) -> f32 {
         let min = self.amount_min.unwrap_or(0);
         let max = self.amount_max.unwrap_or(min);
-        (min + max) as f32 / 2.0
+        // Widen to f32 before adding: `min + max` in u16 arithmetic overflows
+        // (panics in debug, silently wraps in release) once both are above
+        // ~32768, even though each is individually a valid u16.
+        (min as f32 + max as f32) / 2.0
     }
 
     /// Best estimate of precipitation amount in mm.
@@ -339,6 +342,7 @@ impl DailyForecast {
 mod tests {
     use super::*;
     use crate::configs::settings::DashboardSettings;
+    use proptest::prelude::*;
 
     // Nested modules accumulate here as further conversion/formatting test
     // files are migrated (see docs/test-suite-migration-plan.md Phase 2).
@@ -535,6 +539,120 @@ mod tests {
                     domain_forecasts[i].time > domain_forecasts[i - 1].time,
                     "order should be preserved after conversion"
                 );
+            }
+        }
+    }
+
+    /// `from_bom` only has fixed example fixtures to exercise it (see
+    /// `bom_conversion` above); these fuzz the full space of a single API
+    /// entry — extreme temperatures, mismatched min/max, absent optional
+    /// fields — to confirm it never panics, independent of any specific
+    /// expected output.
+    mod bom_conversion_fuzzing {
+        use super::*;
+        use crate::apis::bom::models::{
+            Astronomical as BomAstronomical, DailyEntry, HourlyForecast as BomHourlyForecast,
+            HourlyUV, Rain, RainAmount, RelativeHumidity, Temperature as BomTemperature,
+            Wind as BomWind,
+        };
+
+        /// A timestamp strategy bounded to roughly year 1900-3000 in Unix
+        /// seconds — comfortably inside chrono's representable range, so
+        /// `DateTime::from_timestamp` is always `Some`.
+        fn any_datetime() -> impl Strategy<Value = DateTime<Utc>> {
+            (-2_208_988_800i64..32_503_680_000i64)
+                .prop_map(|secs| DateTime::from_timestamp(secs, 0).unwrap())
+        }
+
+        fn any_bom_temperature() -> impl Strategy<Value = BomTemperature> {
+            (
+                any::<f32>(),
+                prop_oneof![Just(TemperatureUnit::C), Just(TemperatureUnit::F)],
+            )
+                .prop_map(|(value, unit)| BomTemperature { value, unit })
+        }
+
+        prop_compose! {
+            fn any_rain()(
+                min in any::<Option<u16>>(),
+                max in any::<Option<u16>>(),
+                chance in any::<Option<u16>>(),
+            ) -> Rain {
+                Rain { amount: RainAmount { min, max }, chance }
+            }
+        }
+
+        prop_compose! {
+            fn any_bom_wind()(
+                speed_kilometre in any::<u16>(),
+                gust_speed_kilometre in any::<u16>(),
+            ) -> BomWind {
+                BomWind { speed_kilometre, gust_speed_kilometre }
+            }
+        }
+
+        prop_compose! {
+            fn any_hourly_forecast()(
+                rain in any_rain(),
+                temp in any_bom_temperature(),
+                temp_feels_like in any_bom_temperature(),
+                wind in any_bom_wind(),
+                relative_humidity in any::<u16>(),
+                uv in proptest::option::of(any::<u16>()),
+                time in any_datetime(),
+                is_night in any::<bool>(),
+            ) -> BomHourlyForecast {
+                BomHourlyForecast {
+                    rain,
+                    temp,
+                    temp_feels_like,
+                    wind,
+                    relative_humidity: RelativeHumidity(relative_humidity),
+                    uv: uv.map(HourlyUV),
+                    time,
+                    is_night,
+                }
+            }
+        }
+
+        prop_compose! {
+            fn any_astronomical()(
+                sunrise_time in proptest::option::of(any_datetime()),
+                sunset_time in proptest::option::of(any_datetime()),
+            ) -> BomAstronomical {
+                BomAstronomical { sunrise_time, sunset_time }
+            }
+        }
+
+        prop_compose! {
+            fn any_daily_entry()(
+                rain in proptest::option::of(any_rain()),
+                astronomical in proptest::option::of(any_astronomical()),
+                date in proptest::option::of(any_datetime()),
+                temp_max in proptest::option::of(any_bom_temperature()),
+                temp_min in proptest::option::of(any_bom_temperature()),
+            ) -> DailyEntry {
+                DailyEntry {
+                    rain,
+                    astronomical,
+                    date,
+                    temp_max,
+                    temp_min,
+                }
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn from_bom_hourly_never_panics(bom in any_hourly_forecast()) {
+                let settings = DashboardSettings::load_test_config().unwrap();
+                let _ = HourlyForecast::from_bom(bom, &settings);
+            }
+
+            #[test]
+            fn from_bom_daily_never_panics(bom in any_daily_entry()) {
+                let settings = DashboardSettings::load_test_config().unwrap();
+                let _ = DailyForecast::from_bom(bom, &settings);
             }
         }
     }
@@ -960,6 +1078,114 @@ mod tests {
         }
     }
 
+    /// `into_domain` only has fixed example fixtures to exercise it (see
+    /// `open_meteo_conversion` above); these fuzz whole responses — arbitrary
+    /// entry counts and extreme per-field values, all parallel arrays kept
+    /// the same length (the one invariant a real deserialized response always
+    /// has) — to confirm it never panics. `latitude`/`longitude`/`timezone`/
+    /// `*_units` aren't read by `into_domain` at all, so they're left at
+    /// their `Default` rather than fuzzed.
+    mod open_meteo_conversion_fuzzing {
+        use super::*;
+        use crate::apis::open_meteo::models::{
+            Daily, Hourly, OpenMeteoDailyResponse, OpenMeteoHourlyResponse,
+        };
+
+        fn any_datetime() -> impl Strategy<Value = DateTime<Utc>> {
+            (-2_208_988_800i64..32_503_680_000i64)
+                .prop_map(|secs| DateTime::from_timestamp(secs, 0).unwrap())
+        }
+
+        fn any_naive_date() -> impl Strategy<Value = NaiveDate> {
+            any_datetime().prop_map(|dt| dt.date_naive())
+        }
+
+        fn any_naive_datetime() -> impl Strategy<Value = NaiveDateTime> {
+            any_datetime().prop_map(|dt| dt.naive_utc())
+        }
+
+        prop_compose! {
+            /// Binds `count` first, then generates every parallel array at
+            /// exactly that length — mirroring the one invariant a real
+            /// deserialized response always has (all arrays the same size).
+            fn any_hourly()(count in 0usize..8)(
+                time in proptest::collection::vec(any_datetime(), count),
+                temperature_2m in proptest::collection::vec(any::<f32>(), count),
+                apparent_temperature in proptest::collection::vec(any::<f32>(), count),
+                precipitation_probability in proptest::collection::vec(any::<u16>(), count),
+                precipitation in proptest::collection::vec(any::<f32>(), count),
+                snowfall in proptest::collection::vec(any::<f32>(), count),
+                uv_index in proptest::collection::vec(any::<f32>(), count),
+                wind_speed_10m in proptest::collection::vec(any::<f32>(), count),
+                wind_gusts_10m in proptest::collection::vec(any::<f32>(), count),
+                relative_humidity_2m in proptest::collection::vec(any::<u16>(), count),
+                cloud_cover in proptest::collection::vec(proptest::option::of(any::<u16>()), count),
+                is_day in proptest::collection::vec(any::<u16>(), count),
+                weather_code in proptest::option::of(proptest::collection::vec(any::<u8>(), count)),
+            ) -> Hourly {
+                Hourly {
+                    time,
+                    temperature_2m,
+                    apparent_temperature,
+                    precipitation_probability,
+                    precipitation,
+                    snowfall,
+                    uv_index,
+                    wind_speed_10m,
+                    wind_gusts_10m,
+                    relative_humidity_2m,
+                    cloud_cover,
+                    weather_code,
+                    is_day,
+                }
+            }
+        }
+
+        prop_compose! {
+            fn any_daily()(count in 0usize..8)(
+                time in proptest::collection::vec(any_naive_date(), count),
+                sunrise in proptest::collection::vec(any_naive_datetime(), count),
+                sunset in proptest::collection::vec(any_naive_datetime(), count),
+                temperature_2m_max in proptest::collection::vec(any::<f32>(), count),
+                temperature_2m_min in proptest::collection::vec(any::<f32>(), count),
+                precipitation_sum in proptest::collection::vec(any::<f32>(), count),
+                precipitation_probability_max in proptest::collection::vec(any::<u16>(), count),
+                snowfall_sum in proptest::collection::vec(any::<f32>(), count),
+                cloud_cover_mean in proptest::collection::vec(proptest::option::of(any::<u16>()), count),
+                weather_code in proptest::option::of(proptest::collection::vec(any::<u8>(), count)),
+            ) -> Daily {
+                Daily {
+                    time,
+                    sunrise,
+                    sunset,
+                    temperature_2m_max,
+                    temperature_2m_min,
+                    precipitation_sum,
+                    precipitation_probability_max,
+                    snowfall_sum,
+                    cloud_cover_mean,
+                    weather_code,
+                }
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn into_domain_hourly_never_panics(hourly in any_hourly()) {
+                let response = OpenMeteoHourlyResponse { hourly, ..Default::default() };
+                let settings = DashboardSettings::load_test_config().unwrap();
+                let _ = response.into_domain(&settings);
+            }
+
+            #[test]
+            fn into_domain_daily_never_panics(daily in any_daily()) {
+                let response = OpenMeteoDailyResponse { daily, ..Default::default() };
+                let settings = DashboardSettings::load_test_config().unwrap();
+                let _ = response.into_domain(&settings);
+            }
+        }
+    }
+
     /// Australia (Melbourne/Sydney) DST: starts first Sunday in October,
     /// 2:00 AM -> 3:00 AM (AEST -> AEDT); ends first Sunday in April,
     /// 3:00 AM -> 2:00 AM (AEDT -> AEST). Verifies API responses convert to
@@ -1154,6 +1380,23 @@ mod tests {
                 );
             }
         }
+
+        proptest! {
+            /// For the same input speed, km/h (identity) is never smaller than mph,
+            /// and mph is never smaller than knots — the three conversion factors
+            /// (1.0, 0.621371, 0.539957) are strictly ordered, so this holds
+            /// regardless of the exact digits, unlike an assertion that
+            /// re-derives the factors inside the test.
+            #[test]
+            fn kmh_ge_mph_ge_knots_for_any_speed(speed_kmh in any::<u16>()) {
+                let kmh = Wind::convert_speed(speed_kmh, WindSpeedUnit::KmH);
+                let mph = Wind::convert_speed(speed_kmh, WindSpeedUnit::Mph);
+                let knots = Wind::convert_speed(speed_kmh, WindSpeedUnit::Knots);
+
+                prop_assert!(kmh >= mph, "kmh ({kmh}) < mph ({mph}) for {speed_kmh}");
+                prop_assert!(mph >= knots, "mph ({mph}) < knots ({knots}) for {speed_kmh}");
+            }
+        }
     }
 
     /// `is_primarily_snow()` determines whether precipitation is primarily
@@ -1269,6 +1512,57 @@ mod tests {
         fn has_snow_false_with_zero_snowfall() {
             let precip = Precipitation::new_with_snowfall(Some(50), Some(5), Some(10), Some(0));
             assert!(!precip.has_snow());
+        }
+
+        proptest! {
+            /// `is_primarily_snow` reads `snowfall_amount` first and returns
+            /// `false` immediately when it's zero or absent, before `amount()`
+            /// (built from `amount_min`/`amount_max`) is even computed — and
+            /// `chance` never enters the calculation at all. Holds for any
+            /// combination of the other three fields, not just the fixed
+            /// examples above.
+            #[test]
+            fn zero_or_absent_snowfall_is_never_primarily_snow(
+                chance in any::<Option<u16>>(),
+                amount_min in any::<Option<u16>>(),
+                amount_max in any::<Option<u16>>(),
+                snowfall_is_absent in any::<bool>(),
+            ) {
+                let precip = Precipitation {
+                    chance,
+                    amount_min,
+                    amount_max,
+                    snowfall_amount: if snowfall_is_absent { None } else { Some(0) },
+                };
+                prop_assert!(!precip.is_primarily_snow());
+            }
+        }
+    }
+
+    /// `amount()` estimates a single precipitation figure from `amount_min`/
+    /// `amount_max`; when both are present it should never report a value
+    /// outside the range the two bounds describe.
+    mod precipitation_amount_bounds {
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn amount_is_within_min_max_when_both_present(
+                amount_min in any::<u16>(),
+                amount_max in any::<u16>(),
+            ) {
+                // Nothing enforces amount_min <= amount_max at the type level,
+                // so this deliberately doesn't assume that ordering either.
+                let precip = Precipitation::new(None, Some(amount_min), Some(amount_max));
+                let amount = precip.amount();
+                let lower = amount_min.min(amount_max) as f32;
+                let upper = amount_min.max(amount_max) as f32;
+
+                prop_assert!(
+                    amount >= lower && amount <= upper,
+                    "amount {amount} out of [{lower}, {upper}] for min={amount_min}, max={amount_max}"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds property-based tests (`proptest`) for the invariants flagged as a gap in
the test-suite review (docs/test-suite-review.md), and fixes two real bugs
they found — both are panics on inputs a human writing example-based tests
wouldn't have thought to try.

- `Wind::convert_speed`: for the same input, `km/h >= mph >= knots` always
  holds, since the three conversion factors are strictly ordered (checked by
  brute force across the full `u16` range before encoding it as a property).
- `Precipitation::is_primarily_snow`: zero/absent snowfall is never
  "primarily snow", for any `chance`/`amount_min`/`amount_max`.
- `Precipitation::amount()`/`median()`: result always falls within
  `[min(amount_min, amount_max), max(...)]` when both bounds are present —
  true of any arithmetic mean, so the property doesn't need to restate the
  averaging formula.
- `HourlyForecast::from_bom`/`DailyForecast::from_bom` and
  `OpenMeteoHourlyResponse`/`OpenMeteoDailyResponse::into_domain`: fuzzed with
  extreme/arbitrary field values to confirm they never panic.
- `is_valid_date_format`: fuzzed with arbitrary strings to confirm it never
  panics, since it validates user-supplied config, not just internal data.

Each property was chosen to state an invariant independent of the exact
constants/formula in the implementation, rather than re-deriving the
function's own arithmetic inside the test (which would prove nothing).

## Bugs found and fixed

1. **`Precipitation::median()` — integer overflow.** `(min + max) as f32 /
   2.0` computed the addition in `u16` arithmetic before casting, so two
   individually-valid `u16` values (e.g. `52403` and `13133`) could overflow
   — panicking in debug builds, silently wrapping to a wrong result in
   release. Nothing constrains `amount_min`/`amount_max` to a realistic
   precipitation range, so this wasn't reachable only in theory. Fixed by
   widening to `f32` before adding.

2. **`is_valid_date_format` — panic on malformed format specifiers.** The
   function called `.format(trimmed).to_string()`; chrono's `DelayedFormat`
   can return `Err` from `Display::fmt` for certain malformed specifiers
   (minimal repro: `"%{"`), and `ToString::to_string()` assumes `Display::fmt`
   never fails — it panics if it does, with no way to recover. Since this
   function is wired in as `DateFormat`'s `nutype` validator
   (`configs/settings.rs`), a malformed `date_format` value in a user's
   config crashed the whole process during config load (raw panic/backtrace)
   instead of being cleanly rejected the way every other invalid format
   already was (empty, whitespace-only, output-too-long). Fixed by writing
   into a buffer via `std::fmt::Write` and propagating a formatting failure
   as a normal `ValidationError`.

Both regression cases are saved under `proptest-regressions/` for
deterministic replay in future runs.

## Test plan

- [x] `cargo test` — 198 passed, 0 failed, 0 ignored (was 190 before this
      branch; +8 new property/fuzz tests: 3 arithmetic invariants, 4
      no-panic conversion fuzz tests, 1 date-format fuzz test)
- [x] `cargo clippy --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-push hook (fmt + clippy + full suite + snapshot tests) — passed

